### PR TITLE
The PreBuildValidator tool has been adapted 

### DIFF
--- a/Exceptions/ValidationException.cs
+++ b/Exceptions/ValidationException.cs
@@ -1,0 +1,12 @@
+﻿namespace SOLTEC.PreBuildValidator.Exceptions;
+
+/// <summary>
+/// Represents an exception thrown when a validation fails in the pre-build validator.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="ValidationException"/> class with a specific message.
+/// </remarks>
+/// <param name="message">The message describing the validation error.</param>
+public class ValidationException(string message) : Exception(message)
+{
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
-﻿using SOLTEC.PreBuildValidator.Validators;
+﻿using SOLTEC.PreBuildValidator.Exceptions;
+using SOLTEC.PreBuildValidator.Validators;
 
 namespace SOLTEC.PreBuildValidator;
 
@@ -8,98 +9,152 @@ namespace SOLTEC.PreBuildValidator;
 /// </summary>
 /// <example>
 /// <![CDATA[
-/// dotnet run --project Tools/SOLTEC.PreBuildValidator
+/// dotnet run --project Tools/SOLTEC.PreBuildValidator ProjectFileWithPath.csprj
 /// ]]>
 /// </example>
-public static class Program
+public class Program
 {
-
     /// <summary>
     /// Main entry point of the validator.
     /// </summary>
-    public static void Main()
+    private static void Main(string[] args)
     {
-        var _csolutionDirectory = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE")
-                                ?? Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../.."));
-        bool _success = true;
-
-        Console.OutputEncoding = System.Text.Encoding.UTF8;
-        Console.WriteLine("🔍 Starting project validation......");
-        try
+        // Validate arguments
+        if (args.Length == 0)
         {
-            Console.WriteLine("📄 Checking LangVersion and Nullable in project...");
-            LangVersionValidator.ValidateLangVersion(_csolutionDirectory);
-        }
-        catch (Exception ex)
-        {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine($"❌ LangVersion or Nullable validation failed: {ex.Message}");
-            Console.ResetColor();
-            _success = false;
-        }
-        try
-        {
-            Console.WriteLine("📝 Checking XML documentation...");
-            XmlDocValidator.ValidateXmlDocumentation(_csolutionDirectory);
-        }
-        catch (Exception ex)
-        {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine($"❌ XML documentation validation failed: {ex.Message}");
-            Console.ResetColor();
-            _success = false;
-        }
-
-        try
-        {
-            Console.WriteLine("🧠 Checking TODO / FIXME...");
-            TodoFixmeValidator.ValidateTodoFixme(_csolutionDirectory);
-        }
-        catch (Exception ex)
-        {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine($"❌ TODO/FIXME validation failed: {ex.Message}");
-            Console.ResetColor();
-            _success = false;
-        }
-
-        try
-        {
-            Console.WriteLine("📊 Checking test coverage by class...");
-            TestCoverageValidator.ValidateTestCoverage(_csolutionDirectory);
-        }
-        catch (Exception ex)
-        {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine($"❌ Test coverage validation failed: {ex.Message}");
-            Console.ResetColor();
-            _success = false;
-        }
-
-        try
-        {
-            Console.WriteLine("🧪 Checking whether tests exist in unit testing projects...");
-            TestMethodPresenceValidator.ValidateTestMethods(_csolutionDirectory);
-        }
-        catch (Exception ex)
-        {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine($"❌ Test coverage validation failed: {ex.Message}");
-            Console.ResetColor();
-            _success = false;
-        }
-
-        if (_success)
-        {
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine("✅ All validations passed successfully.");
-        }
-        else
-        {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine("❌ Validation failed. Please fix the issues above.");
+            Console.WriteLine("Error: Project name must be provided as an argument (e.g., SOLTEC.Core).");
             Environment.Exit(1);
         }
-        Console.ResetColor();
+
+        var _projectName = args[0];
+        var _solutionDirectory = Directory.GetParent(AppDomain.CurrentDomain.BaseDirectory)?.Parent?.Parent?.Parent?.FullName
+                                 ?? throw new DirectoryNotFoundException("Could not determine the solution directory.");
+
+        Console.WriteLine($"Solution Directory: {_solutionDirectory}");
+        Console.WriteLine($"Project to validate: {_projectName}");
+
+        try
+        {
+            LangVersionValidator.ValidateLangVersion(_solutionDirectory, _projectName);
+            TestCoverageValidator.ValidateTestCoverage(_solutionDirectory, _projectName);
+            TestMethodPresenceValidator.ValidateTestMethodPresence(_solutionDirectory, _projectName);
+            TodoFixmeValidator.ValidateTodoFixme(_solutionDirectory, _projectName);
+            XmlDocValidator.ValidateXmlDocumentation(_solutionDirectory, _projectName);
+
+            Console.WriteLine("Pre-build validation completed successfully.");
+        }
+        catch (ValidationException _vex)
+        {
+            Console.WriteLine($"Validation failed: {_vex.Message}");
+            Environment.Exit(1);
+        }
+        catch (Exception _ex)
+        {
+            Console.WriteLine($"Unexpected error: {_ex.Message}");
+            Environment.Exit(1);
+        }
     }
 }
+//namespace SOLTEC.PreBuildValidator;
+
+///// <summary>
+///// Entry point for the SOLTEC.PreBuildValidator tool.
+///// Performs pre-build checks such as LangVersion, Nullable, XML documentation, TODO/FIXME comments, and test validation.
+///// </summary>
+///// <example>
+///// <![CDATA[
+///// dotnet run --project Tools/SOLTEC.PreBuildValidator
+///// ]]>
+///// </example>
+//public static class Program
+//{
+
+//    /// <summary>
+//    /// Main entry point of the validator.
+//    /// </summary>
+//    public static void Main()
+//    {
+//        var _csolutionDirectory = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE")
+//                                ?? Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../.."));
+//        bool _success = true;
+
+//        Console.OutputEncoding = System.Text.Encoding.UTF8;
+//        Console.WriteLine("🔍 Starting project validation......");
+//        try
+//        {
+//            Console.WriteLine("📄 Checking LangVersion and Nullable in project...");
+//            LangVersionValidator.ValidateLangVersion(_csolutionDirectory);
+//        }
+//        catch (Exception ex)
+//        {
+//            Console.ForegroundColor = ConsoleColor.Red;
+//            Console.WriteLine($"❌ LangVersion or Nullable validation failed: {ex.Message}");
+//            Console.ResetColor();
+//            _success = false;
+//        }
+//        try
+//        {
+//            Console.WriteLine("📝 Checking XML documentation...");
+//            XmlDocValidator.ValidateXmlDocumentation(_csolutionDirectory);
+//        }
+//        catch (Exception ex)
+//        {
+//            Console.ForegroundColor = ConsoleColor.Red;
+//            Console.WriteLine($"❌ XML documentation validation failed: {ex.Message}");
+//            Console.ResetColor();
+//            _success = false;
+//        }
+
+//        try
+//        {
+//            Console.WriteLine("🧠 Checking TODO / FIXME...");
+//            TodoFixmeValidator.ValidateTodoFixme(_csolutionDirectory);
+//        }
+//        catch (Exception ex)
+//        {
+//            Console.ForegroundColor = ConsoleColor.Red;
+//            Console.WriteLine($"❌ TODO/FIXME validation failed: {ex.Message}");
+//            Console.ResetColor();
+//            _success = false;
+//        }
+
+//        try
+//        {
+//            Console.WriteLine("📊 Checking test coverage by class...");
+//            TestCoverageValidator.ValidateTestCoverage(_csolutionDirectory);
+//        }
+//        catch (Exception ex)
+//        {
+//            Console.ForegroundColor = ConsoleColor.Red;
+//            Console.WriteLine($"❌ Test coverage validation failed: {ex.Message}");
+//            Console.ResetColor();
+//            _success = false;
+//        }
+
+//        try
+//        {
+//            Console.WriteLine("🧪 Checking whether tests exist in unit testing projects...");
+//            TestMethodPresenceValidator.ValidateTestMethods(_csolutionDirectory);
+//        }
+//        catch (Exception ex)
+//        {
+//            Console.ForegroundColor = ConsoleColor.Red;
+//            Console.WriteLine($"❌ Test coverage validation failed: {ex.Message}");
+//            Console.ResetColor();
+//            _success = false;
+//        }
+
+//        if (_success)
+//        {
+//            Console.ForegroundColor = ConsoleColor.Green;
+//            Console.WriteLine("✅ All validations passed successfully.");
+//        }
+//        else
+//        {
+//            Console.ForegroundColor = ConsoleColor.Red;
+//            Console.WriteLine("❌ Validation failed. Please fix the issues above.");
+//            Environment.Exit(1);
+//        }
+//        Console.ResetColor();
+//    }
+//}

--- a/README.md
+++ b/README.md
@@ -1,28 +1,115 @@
 # SOLTEC.PreBuildValidator
 
-**SOLTEC.PreBuildValidator** is a .NET 8 console utility designed to run automated pre-build checks on your main SOLTEC.Core project before generating documentation or releasing builds.
+## 📚 Overview
 
-## 🔍 Purpose
+**SOLTEC.PreBuildValidator** is a lightweight console application that validates essential project rules **before allowing the build to succeed**.
 
-- Validate structure, naming conventions, and documentation of public classes and enumerations.
-- Prevent deployment of incomplete or undocumented components.
-- Improve consistency across the SOLTEC codebase before pushing to GitHub or regenerating the wiki.
+It ensures that the codebase remains clean, documented, tested, and properly configured according to the project standards.
 
-## 🛠️ Features
+---
 
-- Automatically locates the project based on the .sln structure.
-- Scans for:
-  - Missing XML documentation
-  - Incomplete `example` blocks
-  - Naming violations (e.g., class/member prefixes)
-  - Incomplete enums or undocumented members
+## 🚀 Key Features
 
-## 🚀 Usage
+- **Language Version Validation**: Ensures the project defines a valid `<LangVersion>` in the `.csproj` file.
+- **Test Coverage Validation**: Ensures that each public/protected class has a corresponding test class.
+- **Test Method Presence Validation**: Ensures that each public/protected method has a corresponding test method.
+- **TODO/FIXME Validation**: Ensures that no TODO or FIXME comments are left in the production code.
+- **XML Documentation Validation**: Ensures that all public/protected classes, methods, and properties have XML documentation comments (`///`).
 
-Use the provided scripts to build and run the validator:
+---
+
+## 🛠️ Technologies Used
+
+- **.NET 8.0**
+- **C# 12**
+- **Top-Level Statements** for the Program entry point
+- **Custom ValidationException** for clear error handling
+- **Regex-optimized validation engines** for code parsing
+
+---
+
+## 📋 How It Works
+
+Upon building the main project (e.g., `SOLTEC.Core`),  
+**this validator runs automatically as a Post-Build event** and:
+
+1. Validates that all coding and documentation standards are met.
+2. Throws a clear and specific error if any validation fails.
+3. Stops the build process if errors are detected.
+
+If all validations pass, the build succeeds.
+
+---
+
+## ⚙️ Usage
+
+### 🎯 Command to Execute
+
+The validator **must receive** the name of the project/solution as a command-line argument.
+
+Example:
+
+```bash
+SOLTEC.PreBuildValidator.exe SOLTEC.Core
 ```
-./run-validator.sh       # Linux/macOS
-run-validator.bat        # Windows
+
+Where:
+- `"SOLTEC.Core"` is the project name to validate (folder and `.csproj` file should match).
+
+---
+
+### 📄 Post-Build Integration (SOLTEC.Core.csproj)
+
+Ensure your `.csproj` file (e.g., `SOLTEC.Core.csproj`) includes:
+
+```xml
+<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <Exec Command="&quot;$(SolutionDir)Tools\SOLTEC.PreBuildValidator\bin\Debug\net8.0\SOLTEC.PreBuildValidator.exe&quot; SOLTEC.Core" />
+</Target>
 ```
 
-> The tool returns a clear success/failure status and highlights violations in the console.
+✅ This guarantees that every build will run the validation automatically.
+
+---
+
+## 📑 Validation Flow
+
+| Validation Step | Description |
+|:---|:---|
+| LangVersionValidator | Verifies the existence and content of `<LangVersion>` in the `.csproj`. |
+| TestCoverageValidator | Ensures every public/protected class has a corresponding test class. |
+| TestMethodPresenceValidator | Ensures every public/protected method has at least one test method. |
+| TodoFixmeValidator | Detects any TODO or FIXME comments in production code. |
+| XmlDocValidator | Validates XML documentation for all public/protected members. |
+
+---
+
+## 🛑 Failure Handling
+
+If a validation fails:
+
+- A **ValidationException** will be thrown.
+- A clear and detailed message will be shown in the console.
+- The build process will stop immediately.
+- You must fix the indicated problem before building successfully.
+
+Example error output:
+
+```plaintext
+Validation failed: Test coverage validation failed: The following classes are missing corresponding test classes: CustomerService, OrderManager.
+```
+
+---
+
+## 📢 Notes
+
+- Generated files such as `.Designer.cs`, `.g.cs`, and `.AssemblyInfo.cs` are automatically excluded from validations.
+- The validator is extensible: more validation rules can be added easily if needed.
+
+---
+
+## 👨‍💻 Author
+
+Developed and maintained by JuanMa.
+
+---

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,28 +1,115 @@
 # SOLTEC.PreBuildValidator
 
-**SOLTEC.PreBuildValidator** es una herramienta de consola para .NET 8 diseñada para ejecutar validaciones automáticas antes de compilar el proyecto principal `SOLTEC.Core`.
+## 📚 Resumen
 
-## 🔍 Propósito
+**SOLTEC.PreBuildValidator** es una aplicación de consola ligera que valida reglas esenciales del proyecto **antes de permitir que la compilación tenga éxito**.
 
-- Validar estructura, convenciones de nombres y documentación XML.
-- Prevenir despliegues con componentes incompletos o sin documentar.
-- Asegurar consistencia antes de subir a GitHub o regenerar la wiki.
+Garantiza que la base de código permanezca limpia, documentada, probada y configurada correctamente según los estándares del proyecto.
 
-## 🛠️ Funcionalidades
+---
 
-- Detecta automáticamente el proyecto a validar a partir del archivo `.sln`.
-- Escanea en busca de:
-  - Comentarios XML faltantes
-  - Bloques `example` incompletos
-  - Violaciones de nomenclatura (prefijos incorrectos)
-  - Enumeraciones sin documentar
+## 🚀 Características principales
 
-## 🚀 Uso
+- **Validación de versión de lenguaje**: Asegura que el proyecto defina un `<LangVersion>` válido en el archivo `.csproj`.
+- **Validación de cobertura de pruebas**: Garantiza que cada clase pública/protegida tenga una clase de prueba correspondiente.
+- **Validación de presencia de métodos de prueba**: Verifica que cada método público/protegido tenga al menos un método de prueba.
+- **Validación de TODO/FIXME**: Detecta comentarios TODO o FIXME que hayan quedado en el código de producción.
+- **Validación de documentación XML**: Asegura que todas las clases, métodos y propiedades públicas/protegidas tengan comentarios de documentación XML (`///`).
 
-Utiliza los scripts incluidos para compilar y ejecutar el validador:
+---
+
+## 🛠️ Tecnologías utilizadas
+
+- **.NET 8.0**
+- **C# 12**
+- **Top-Level Statements** para el punto de entrada del programa
+- **Excepción personalizada ValidationException** para un manejo de errores claro
+- **Motores de validación optimizados con Regex** para el análisis de código
+
+---
+
+## 📋 Funcionamiento
+
+Al compilar el proyecto principal (por ejemplo, `SOLTEC.Core`),  
+**este validador se ejecuta automáticamente como un evento Post-Build** y:
+
+1. Valida que se cumplan todos los estándares de codificación y documentación.
+2. Lanza un error claro y específico si alguna validación falla.
+3. Detiene el proceso de compilación si se detectan errores.
+
+Si todas las validaciones pasan, la compilación tiene éxito.
+
+---
+
+## ⚙️ Uso
+
+### 🎯 Comando para ejecutar
+
+El validador **debe recibir** el nombre del proyecto/solución como argumento en la línea de comandos.
+
+Ejemplo:
+
+```bash
+SOLTEC.PreBuildValidator.exe SOLTEC.Core
 ```
-./run-validator.sh       # Linux/macOS
-run-validator.bat        # Windows
+
+Donde:
+- `"SOLTEC.Core"` es el nombre del proyecto que se desea validar (el nombre de la carpeta y el archivo `.csproj` deben coincidir).
+
+---
+
+### 📄 Integración Post-Build (SOLTEC.Core.csproj)
+
+Asegúrate de que tu archivo `.csproj` (por ejemplo, `SOLTEC.Core.csproj`) incluya:
+
+```xml
+<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <Exec Command="&quot;$(SolutionDir)Tools\SOLTEC.PreBuildValidator\bin\Debug\net8.0\SOLTEC.PreBuildValidator.exe&quot; SOLTEC.Core" />
+</Target>
 ```
 
-> La herramienta devuelve un estado claro de éxito o fallo, y muestra los errores directamente en consola.
+✅ Esto garantiza que cada vez que se construya el proyecto, se ejecutará automáticamente la validación.
+
+---
+
+## 📑 Flujo de validación
+
+| Paso de validación | Descripción |
+|:---|:---|
+| LangVersionValidator | Verifica la existencia y el contenido de `<LangVersion>` en el `.csproj`. |
+| TestCoverageValidator | Asegura que cada clase pública/protegida tenga una clase de prueba correspondiente. |
+| TestMethodPresenceValidator | Verifica que cada método público/protegido tenga al menos un método de prueba. |
+| TodoFixmeValidator | Detecta cualquier comentario TODO o FIXME en el código de producción. |
+| XmlDocValidator | Valida la documentación XML para todos los miembros públicos/protegidos. |
+
+---
+
+## 🛑 Manejo de errores
+
+Si falla alguna validación:
+
+- Se lanzará una **ValidationException**.
+- Se mostrará un mensaje claro y detallado en la consola.
+- El proceso de compilación se detendrá inmediatamente.
+- Deberás corregir el problema indicado antes de compilar nuevamente.
+
+Ejemplo de salida de error:
+
+```plaintext
+Validation failed: Test coverage validation failed: The following classes are missing corresponding test classes: CustomerService, OrderManager.
+```
+
+---
+
+## 📢 Notas
+
+- Los archivos generados automáticamente como `.Designer.cs`, `.g.cs` y `.AssemblyInfo.cs` son excluidos de las validaciones.
+- El validador es extensible: se pueden añadir nuevas reglas de validación fácilmente si se requiere.
+
+---
+
+## 👨‍💻 Autor
+
+Desarrollado y mantenido por JuanMa.
+
+---

--- a/README_RUN_VALIDATOR.md
+++ b/README_RUN_VALIDATOR.md
@@ -1,31 +1,71 @@
-﻿# Script Instructions - SOLTEC.PreBuildValidator
+# SOLTEC.PreBuildValidator - Manual Run Guide
 
-This folder includes two scripts to build and run the pre-build validator tool.
+## 📚 Purpose
 
-They are designed to work **regardless of your current working directory**.
+This document explains how to manually run the **SOLTEC.PreBuildValidator** without depending on the build process.
 
-## 🚀 Windows
+It is useful for standalone validation checks during development, CI/CD pipelines, or before merging changes into the main branch.
 
-To run the validator:
-```
-run-validator.bat
-```
+---
 
-This script:
-1. Changes to the script's directory
-2. Builds the project using `dotnet build`
-3. Runs the resulting DLL validator
+## 🚀 How to Run
 
-## 🐧 Linux/macOS
+To execute the validator manually, you must run the executable **and provide the project name as an argument**.
 
-Make the script executable:
+### 🎯 Command Example
+
 ```bash
-chmod +x run-validator.sh
+SOLTEC.PreBuildValidator.exe SOLTEC.Core
 ```
 
-Then run:
-```bash
-./run-validator.sh
+Where:
+- `SOLTEC.Core` is the name of the project folder and `.csproj` file you want to validate.
+
+✅ **Passing the project name is mandatory**.
+✅ **Without this argument, the validator will throw an error and exit.**
+
+---
+
+## 📋 What Happens During Execution
+
+When you run the validator:
+
+1. It will check the project structure and codebase.
+2. It will validate:
+   - Presence of `<LangVersion>` in the `.csproj`.
+   - Test coverage for classes.
+   - Presence of test methods for public/protected methods.
+   - Absence of TODO/FIXME comments.
+   - XML documentation for public/protected classes, methods, and properties.
+
+---
+
+## 🛑 Failure Handling
+
+If any validation fails:
+
+- A **ValidationException** will be thrown.
+- The error will clearly describe the issue.
+- The application will exit with an error code (`Environment.Exit(1)`).
+
+Example output if a class has no test coverage:
+
+```plaintext
+Validation failed: Test coverage validation failed: The following classes are missing corresponding test classes: CustomerService, OrderManager.
 ```
 
-> The validator will automatically check and report any project issues before build.
+---
+
+## 📢 Notes
+
+- Only one top-level executable (Program.cs) exists, ensuring simple and efficient execution.
+- Generated files like `.Designer.cs`, `.g.cs`, and `.AssemblyInfo.cs` are automatically excluded from validation.
+- All validation errors are precise and grouped by type.
+
+---
+
+## 👨‍💻 Author
+
+Developed and maintained by JuanMa.
+
+---

--- a/README_RUN_VALIDATOR_ES.md
+++ b/README_RUN_VALIDATOR_ES.md
@@ -1,31 +1,71 @@
-﻿# Instrucciones para los Scripts - SOLTEC.PreBuildValidator
+# SOLTEC.PreBuildValidator - Guía de Ejecución Manual
 
-Esta carpeta incluye dos scripts para compilar y ejecutar la herramienta de validación previa a la compilación.
+## 📚 Propósito
 
-Están diseñados para funcionar **sin importar desde qué carpeta se ejecuten**.
+Este documento explica cómo ejecutar manualmente el **SOLTEC.PreBuildValidator** sin depender del proceso de compilación.
 
-## 🚀 Windows
+Es útil para realizar validaciones independientes durante el desarrollo, en pipelines de CI/CD, o antes de hacer un merge en la rama principal.
 
-Para ejecutar el validador:
-```
-run-validator.bat
-```
+---
 
-Este script:
-1. Cambia a la carpeta del propio script
-2. Compila el proyecto con `dotnet build`
-3. Ejecuta el DLL resultante del validador
+## 🚀 Cómo Ejecutarlo
 
-## 🐧 Linux/macOS
+Para ejecutar el validador manualmente, debes ejecutar el ejecutable **y proporcionar el nombre del proyecto como argumento**.
 
-Haz que el script sea ejecutable:
+### 🎯 Ejemplo de Comando
+
 ```bash
-chmod +x run-validator.sh
+SOLTEC.PreBuildValidator.exe SOLTEC.Core
 ```
 
-Luego ejecuta:
-```bash
-./run-validator.sh
+Donde:
+- `SOLTEC.Core` es el nombre de la carpeta del proyecto y del archivo `.csproj` que deseas validar.
+
+✅ **Proporcionar el nombre del proyecto es obligatorio**.  
+✅ **Si no se proporciona este argumento, el validador mostrará un error y finalizará.**
+
+---
+
+## 📋 Qué Sucede Durante la Ejecución
+
+Cuando ejecutas el validador:
+
+1. Validará la estructura y el código del proyecto.
+2. Validará:
+   - La presencia de `<LangVersion>` en el `.csproj`.
+   - La cobertura de pruebas para las clases públicas/protegidas.
+   - La existencia de métodos de prueba para métodos públicos/protegidos.
+   - La ausencia de comentarios TODO/FIXME.
+   - La documentación XML de clases, métodos y propiedades públicas/protegidas.
+
+---
+
+## 🛑 Manejo de Fallos
+
+Si alguna validación falla:
+
+- Se lanzará una **ValidationException**.
+- El error describirá claramente el problema encontrado.
+- La aplicación terminará con un código de error (`Environment.Exit(1)`).
+
+Ejemplo de salida si una clase no tiene cobertura de prueba:
+
+```plaintext
+Validation failed: Test coverage validation failed: The following classes are missing corresponding test classes: CustomerService, OrderManager.
 ```
 
-> El validador comprobará automáticamente y reportará cualquier problema en el proyecto antes de compilar.
+---
+
+## 📢 Notas
+
+- Solo existe un único archivo ejecutable con declaraciones de nivel superior (Top-Level Program.cs), garantizando una ejecución simple y eficiente.
+- Archivos generados como `.Designer.cs`, `.g.cs` y `.AssemblyInfo.cs` son excluidos automáticamente de la validación.
+- Todos los errores de validación son precisos y agrupados por tipo de error.
+
+---
+
+## 👨‍💻 Autor
+
+Desarrollado y mantenido por JuanMa.
+
+---

--- a/Validators/LangVersionValidator.cs
+++ b/Validators/LangVersionValidator.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Linq;
+﻿using SOLTEC.PreBuildValidator.Exceptions;
+using System.Xml.Linq;
 
 namespace SOLTEC.PreBuildValidator.Validators;
 
@@ -12,45 +13,89 @@ namespace SOLTEC.PreBuildValidator.Validators;
 /// </example>
 public static class LangVersionValidator
 {
+    ///// <summary>
+    ///// The required C# language version.
+    ///// </summary>
+    //private const string gcRequiredLangVersion = "12.0";
+
+    ///// <summary>
+    ///// Validates that all .csproj files in the solution have LangVersion set to 12.0 and Nullable enabled.
+    ///// </summary>
+    ///// <param name="solutionDirectory">Path to the solution directory to scan.</param>
+    //public static void ValidateLangVersion(string solutionDirectory)
+    //{
+    //    Console.WriteLine("🔍 Starting Checking LangVersion and Nullable in project...");
+
+    //    var _projectFiles = Directory.GetFiles(solutionDirectory, "*.csproj", SearchOption.AllDirectories);
+
+    //    foreach (var _file in _projectFiles)
+    //    {
+    //        Console.WriteLine($"📝 Checking LangVersion and Nullable in project: {_file}...");
+
+    //        try
+    //        {
+    //            var _xdoc = XDocument.Load(_file);
+    //            var _ns = _xdoc.Root?.Name.Namespace;
+    //            var _langVersion = _xdoc.Descendants(_ns + "LangVersion").FirstOrDefault()?.Value?.Trim();
+    //            var _nullable = _xdoc.Descendants(_ns + "Nullable").FirstOrDefault()?.Value?.Trim();
+
+    //            if (_langVersion != gcRequiredLangVersion)
+    //            {
+    //                Console.WriteLine($"❌ {_file}: LangVersion must be {gcRequiredLangVersion} (actual: {_langVersion ?? "NOT DEFINED"})");
+    //            }
+    //            if (_nullable?.ToLowerInvariant() != "enable")
+    //            {
+    //                Console.WriteLine($"❌ {_file}: Nullable must be enabled (actual: {_nullable ?? "NOT DEFINED"})");
+    //            }
+    //        }
+    //        catch (Exception _ex)
+    //        {
+    //            Console.WriteLine($"❌ Error parsing {_file}: {_ex.Message}");
+    //        }
+    //    }
+    //}
+
     /// <summary>
     /// The required C# language version.
     /// </summary>
     private const string gcRequiredLangVersion = "12.0";
 
     /// <summary>
-    /// Validates that all .csproj files in the solution have LangVersion set to 12.0 and Nullable enabled.
+    /// Validates the presence of LangVersion in the project file (.csproj).
     /// </summary>
-    /// <param name="solutionDirectory">Path to the solution directory to scan.</param>
-    public static void ValidateLangVersion(string solutionDirectory)
+    /// <param name="solutionDirectory">Root directory of the solution.</param>
+    /// <param name="projectName">Name of the main project (e.g., SOLTEC.Core).</param>
+    /// <exception cref="ValidationException">Thrown if LangVersion is missing or unreadable.</exception>
+    public static void ValidateLangVersion(string solutionDirectory, string projectName)
     {
-        Console.WriteLine("🔍 Starting Checking LangVersion and Nullable in project...");
+        Console.WriteLine("Starting LangVersion validation...");
 
-        var _projectFiles = Directory.GetFiles(solutionDirectory, "*.csproj", SearchOption.AllDirectories);
+        var _csprojPath = Path.Combine(solutionDirectory, projectName, $"{projectName}.csproj");
 
-        foreach (var _file in _projectFiles)
+        if (!File.Exists(_csprojPath))
         {
-            Console.WriteLine($"📝 Checking LangVersion and Nullable in project: {_file}...");
+            throw new ValidationException($"LangVersion validation failed: Project file '{_csprojPath}' was not found.");
+        }
+        try
+        {
+            var _csprojContent = XDocument.Load(_csprojPath);
+            var _langVersionElement = _csprojContent
+                .Descendants()
+                .FirstOrDefault(x => x.Name.LocalName == "LangVersion");
 
-            try
+            if (_langVersionElement == null || string.IsNullOrWhiteSpace(_langVersionElement.Value))
             {
-                var _xdoc = XDocument.Load(_file);
-                var _ns = _xdoc.Root?.Name.Namespace;
-                var _langVersion = _xdoc.Descendants(_ns + "LangVersion").FirstOrDefault()?.Value?.Trim();
-                var _nullable = _xdoc.Descendants(_ns + "Nullable").FirstOrDefault()?.Value?.Trim();
-
-                if (_langVersion != gcRequiredLangVersion)
-                {
-                    Console.WriteLine($"❌ {_file}: LangVersion must be {gcRequiredLangVersion} (actual: {_langVersion ?? "NOT DEFINED"})");
-                }
-                if (_nullable?.ToLowerInvariant() != "enable")
-                {
-                    Console.WriteLine($"❌ {_file}: Nullable must be enabled (actual: {_nullable ?? "NOT DEFINED"})");
-                }
+                throw new ValidationException($"LangVersion validation failed: No <LangVersion> element found or it is empty in '{_csprojPath}'.");
             }
-            catch (Exception _ex)
+            if (_langVersionElement.Value != gcRequiredLangVersion)
             {
-                Console.WriteLine($"❌ Error parsing {_file}: {_ex.Message}");
+                Console.WriteLine($"❌ LangVersion must be {gcRequiredLangVersion} (actual: {_langVersionElement.Value ?? "NOT DEFINED"})");
             }
+            Console.WriteLine($"LangVersion validation passed: Found LangVersion = {_langVersionElement.Value!.Trim()}");
+        }
+        catch (Exception ex)
+        {
+            throw new ValidationException($"LangVersion validation failed: Unable to read or parse '{_csprojPath}'. Details: {ex.Message}");
         }
     }
 }

--- a/Validators/TestMethodPresenceValidator.cs
+++ b/Validators/TestMethodPresenceValidator.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using SOLTEC.PreBuildValidator.Exceptions;
+using System.Text.RegularExpressions;
 
 namespace SOLTEC.PreBuildValidator.Validators;
 
@@ -13,46 +14,123 @@ namespace SOLTEC.PreBuildValidator.Validators;
 /// </example>
 public static class TestMethodPresenceValidator
 {
+    ///// <summary>
+    ///// Checks that all test classes have at least one [Fact] or [Test] method defined.
+    ///// </summary>
+    ///// <param name="solutionDirectory">Root path of the solution to scan.</param>
+    //public static void ValidateTestMethods(string solutionDirectory)
+    //{
+    //    Console.WriteLine("🔍 Starting Checking whether tests exist in unit testing projects...");
+
+    //    var _testFiles = Directory.GetFiles(solutionDirectory, "*.cs", SearchOption.AllDirectories)
+    //        .Where(_file =>
+    //            _file.Contains("Tests") &&
+    //            !_file.Contains("bin") &&
+    //            !_file.Contains("obj"))
+    //        .ToList();
+
+    //    foreach (var _file in _testFiles)
+    //    {
+    //        var _content = File.ReadAllText(_file);
+    //        var _lines = _content.Split('\n');
+
+    //        // Skip enums from test validation
+    //        if (_lines.Any(c => c.TrimStart().StartsWith("public enum")))
+    //            continue;
+
+    //        var _classMatch = Regex.Match(_content, @"public\s+class\s+(\w+)", RegexOptions.Multiline);
+
+    //        if (_classMatch.Success)
+    //        {
+    //            var _className = _classMatch.Groups[1].Value;
+    //            var _hasTestAttribute = _content.Contains("[Fact]") || _content.Contains("[Test]");
+
+    //            if (!_hasTestAttribute)
+    //            {
+    //                Console.WriteLine($"❌ {_file}: Missing test method ([Fact] or [Test]) in class {_className}");
+    //            }
+    //            else
+    //            {
+    //                Console.WriteLine($"✅ {_file}: Test method found in class {_className}");
+    //            }
+    //        }
+    //    }
+    //}
+
+    private static readonly Regex _methodRegex = new(@"\b(public|protected)\s+(async\s+)?(\w+\s+)+(\w+)\s*\(", RegexOptions.Compiled);
+
     /// <summary>
-    /// Checks that all test classes have at least one [Fact] or [Test] method defined.
+    /// Validates the presence of test methods for each public/protected method.
     /// </summary>
-    /// <param name="solutionDirectory">Root path of the solution to scan.</param>
-    public static void ValidateTestMethods(string solutionDirectory)
+    /// <param name="solutionDirectory">Root directory of the solution.</param>
+    /// <param name="projectName">Name of the project to validate.</param>
+    /// <exception cref="ValidationException">Thrown if any method lacks a corresponding test method.</exception>
+    public static void ValidateTestMethodPresence(string solutionDirectory, string projectName)
     {
-        Console.WriteLine("🔍 Starting Checking whether tests exist in unit testing projects...");
+        Console.WriteLine("Starting test method presence validation...");
 
-        var _testFiles = Directory.GetFiles(solutionDirectory, "*.cs", SearchOption.AllDirectories)
-            .Where(_file =>
-                _file.Contains("Tests") &&
-                !_file.Contains("bin") &&
-                !_file.Contains("obj"))
-            .ToList();
+        var _projectPath = Path.Combine(solutionDirectory, projectName);
 
-        foreach (var _file in _testFiles)
+        if (!Directory.Exists(_projectPath))
         {
-            var _content = File.ReadAllText(_file);
-            var _lines = _content.Split('\n');
+            throw new ValidationException($"Test method presence validation failed: Project path '{_projectPath}' not found.");
+        }
+        var _projectFiles = Directory.GetFiles(_projectPath, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !IsGeneratedFile(f))
+            .ToList();
+        if (_projectFiles.Count == 0)
+        {
+            throw new ValidationException($"Test method presence validation failed: No .cs files found in '{_projectPath}'.");
+        }
 
-            // Skip enums from test validation
-            if (_lines.Any(c => c.TrimStart().StartsWith("public enum")))
-                continue;
+        var _methodsToCheck = new List<string>();
 
-            var _classMatch = Regex.Match(_content, @"public\s+class\s+(\w+)", RegexOptions.Multiline);
-
-            if (_classMatch.Success)
+        foreach (var _filePath in _projectFiles)
+        {
+            foreach (var _line in File.ReadLines(_filePath))
             {
-                var _className = _classMatch.Groups[1].Value;
-                var _hasTestAttribute = _content.Contains("[Fact]") || _content.Contains("[Test]");
-
-                if (!_hasTestAttribute)
+                var _match = _methodRegex.Match(_line);
+                if (_match.Success)
                 {
-                    Console.WriteLine($"❌ {_file}: Missing test method ([Fact] or [Test]) in class {_className}");
-                }
-                else
-                {
-                    Console.WriteLine($"✅ {_file}: Test method found in class {_className}");
+                    var _methodName = _match.Groups[4].Value;
+                    _methodsToCheck.Add(_methodName);
                 }
             }
         }
+        if (_methodsToCheck.Count == 0)
+        {
+            Console.WriteLine("No public or protected methods found to validate.");
+            return;
+        }
+
+        var _testsDirectory = Path.Combine(solutionDirectory, "Tests");
+        if (!Directory.Exists(_testsDirectory))
+        {
+            throw new ValidationException($"Test method presence validation failed: Tests directory '{_testsDirectory}' not found.");
+        }
+
+        var _testFilesContent = Directory.GetFiles(_testsDirectory, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !IsGeneratedFile(f))
+            .SelectMany(f => File.ReadLines(f))
+            .ToList();
+        var _methodsWithoutTest = _methodsToCheck
+            .Where(methodName => !_testFilesContent.Any(line => line.Contains(methodName)))
+            .ToList();
+
+        if (_methodsWithoutTest.Count != 0)
+        {
+            throw new ValidationException(
+                $"Test method presence validation failed: The following methods are missing corresponding test methods: {string.Join(", ", _methodsWithoutTest)}."
+            );
+        }
+        Console.WriteLine("Test method presence validation passed.");
+    }
+
+    private static bool IsGeneratedFile(string filePath)
+    {
+        var _fileName = Path.GetFileName(filePath);
+        return _fileName.EndsWith(".Designer.cs", StringComparison.OrdinalIgnoreCase) ||
+               _fileName.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase) ||
+               _fileName.EndsWith(".AssemblyInfo.cs", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Validators/TodoFixmeValidator.cs
+++ b/Validators/TodoFixmeValidator.cs
@@ -1,4 +1,7 @@
-﻿namespace SOLTEC.PreBuildValidator.Validators;
+﻿using SOLTEC.PreBuildValidator.Exceptions;
+using System.Text.RegularExpressions;
+
+namespace SOLTEC.PreBuildValidator.Validators;
 
 /// <summary>
 /// Scans all C# files in a given directory to detect unresolved TODO or FIXME comments.
@@ -11,28 +14,85 @@
 /// </example>
 public static class TodoFixmeValidator
 {
+    ///// <summary>
+    ///// Validates the presence of TODO or FIXME comments in source files, marking them as pending issues.
+    ///// </summary>
+    ///// <param name="solutionDirectory">Root path to the solution where files should be checked.</param>
+    //public static void ValidateTodoFixme(string solutionDirectory)
+    //{
+    //    Console.WriteLine("🔍 Starting Checking TODO / FIXME...");
+
+    //    var _csFiles = Directory.GetFiles(solutionDirectory, "*.cs", SearchOption.AllDirectories);
+
+    //    foreach (var _file in _csFiles)
+    //    {
+    //        Console.WriteLine($"📝 Checking TODO/FIXME in file: {_file}...");
+    //        var _lines = File.ReadAllLines(_file);
+
+    //        for (var _i = 0; _i < _lines.Length; _i++)
+    //        {
+    //            if (_lines[_i].Contains("TODO") || _lines[_i].Contains("FIXME"))
+    //            {
+    //                Console.WriteLine($"❌ {_file}: Unresolved TODO/FIXME found at line {_i + 1}: {_lines[_i].Trim()}");
+    //            }
+    //        }
+    //    }
+    //}
+    private static readonly Regex _todoFixmeRegex = new(@"//\s*(TODO|FIXME)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
     /// <summary>
-    /// Validates the presence of TODO or FIXME comments in source files, marking them as pending issues.
+    /// Validates the absence of TODO and FIXME comments in source code files.
     /// </summary>
-    /// <param name="solutionDirectory">Root path to the solution where files should be checked.</param>
-    public static void ValidateTodoFixme(string solutionDirectory)
+    /// <param name="solutionDirectory">Root directory of the solution.</param>
+    /// <param name="projectName">Name of the main project.</param>
+    /// <exception cref="ValidationException">Thrown if any TODO or FIXME comment is found.</exception>
+    public static void ValidateTodoFixme(string solutionDirectory, string projectName)
     {
-        Console.WriteLine("🔍 Starting Checking TODO / FIXME...");
+        Console.WriteLine("Starting TODO/FIXME comments validation...");
 
-        var _csFiles = Directory.GetFiles(solutionDirectory, "*.cs", SearchOption.AllDirectories);
+        var _projectPath = Path.Combine(solutionDirectory, projectName);
 
-        foreach (var _file in _csFiles)
+        if (!Directory.Exists(_projectPath))
         {
-            Console.WriteLine($"📝 Checking TODO/FIXME in file: {_file}...");
-            var _lines = File.ReadAllLines(_file);
+            throw new ValidationException($"TODO/FIXME validation failed: Project path '{_projectPath}' not found.");
+        }
 
-            for (var _i = 0; _i < _lines.Length; _i++)
+        var _projectFiles = Directory.GetFiles(_projectPath, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !IsGeneratedFile(f))
+            .ToList();
+
+        if (_projectFiles.Count == 0)
+        {
+            Console.WriteLine("No source files found to validate TODO/FIXME.");
+            return;
+        }
+
+        var _filesWithTodoFixme = new List<string>();
+        foreach (var _filePath in _projectFiles)
+        {
+            var _lines = File.ReadLines(_filePath);
+
+            if (_lines.Any(line => _todoFixmeRegex.IsMatch(line)))
             {
-                if (_lines[_i].Contains("TODO") || _lines[_i].Contains("FIXME"))
-                {
-                    Console.WriteLine($"❌ {_file}: Unresolved TODO/FIXME found at line {_i + 1}: {_lines[_i].Trim()}");
-                }
+                _filesWithTodoFixme.Add(Path.GetFileName(_filePath));
             }
         }
+
+        if (_filesWithTodoFixme.Count != 0)
+        {
+            throw new ValidationException(
+                $"TODO/FIXME validation failed: The following files contain TODO or FIXME comments: {string.Join(", ", _filesWithTodoFixme)}."
+            );
+        }
+
+        Console.WriteLine("TODO/FIXME validation passed.");
+    }
+
+    private static bool IsGeneratedFile(string filePath)
+    {
+        var _fileName = Path.GetFileName(filePath);
+        return _fileName.EndsWith(".Designer.cs", StringComparison.OrdinalIgnoreCase) ||
+               _fileName.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase) ||
+               _fileName.EndsWith(".AssemblyInfo.cs", StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
To accept the path and name of the project to be analyzed as a parameter. A custom exception has also been added to display a clearer error message. This also prevents unnecessary validations from continuing if an error has already occurred during the previous validation.